### PR TITLE
Add support for metadata in gluamapper.Option struct

### DIFF
--- a/gluamapper.go
+++ b/gluamapper.go
@@ -4,10 +4,11 @@ package gluamapper
 import (
 	"errors"
 	"fmt"
-	"github.com/mitchellh/mapstructure"
-	"github.com/yuin/gopher-lua"
 	"regexp"
 	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/yuin/gopher-lua"
 )
 
 // Option is a configuration that is used to create a new mapper.
@@ -18,8 +19,12 @@ type Option struct {
 	// Returns error if unused keys exist.
 	ErrorUnused bool
 
-	// A struct tag name for lua table keys . This defaults to "gluamapper"
+	// A struct tag name for lua table keys. This defaults to "gluamapper"
 	TagName string
+
+	// Metadata contains information about decoding a structure that
+	// is tedious or difficult to get otherwise.
+	Metadata *mapstructure.Metadata
 }
 
 // Mapper maps a lua table to a Go struct pointer.
@@ -50,6 +55,7 @@ func (mapper *Mapper) Map(tbl *lua.LTable, st interface{}) error {
 		Result:           st,
 		TagName:          opt.TagName,
 		ErrorUnused:      opt.ErrorUnused,
+		Metadata:         opt.Metadata,
 	}
 	decoder, err := mapstructure.NewDecoder(config)
 	if err != nil {
@@ -63,13 +69,13 @@ func Map(tbl *lua.LTable, st interface{}) error {
 	return NewMapper(Option{}).Map(tbl, st)
 }
 
-
 // Id is an Option.NameFunc that returns given string as-is.
 func Id(s string) string {
 	return s
 }
 
 var camelre = regexp.MustCompile(`_([a-z])`)
+
 // ToUpperCamelCase is an Option.NameFunc that converts strings from snake case to upper camel case.
 func ToUpperCamelCase(s string) string {
 	return strings.ToUpper(string(s[0])) + camelre.ReplaceAllStringFunc(s[1:len(s)], func(s string) string { return strings.ToUpper(s[1:len(s)]) })


### PR DESCRIPTION
Adding support for metadata allows for inspecting the result of decoding and is useful in situations where we need to verify a list of required fields or unused ones.

A better approach would be to simply embed `mapstructure.DecoderConfig` in `gluamapper.Option`, but doing that would introduce a breaking API change, so with this commit I'm simply adding `mapstructure.Metadata` to `gluamapper.Option` struct for now. In future commits we should probably consider simply embedding DecoderConfig into Option struct.
